### PR TITLE
Display Langtrace version on the UI

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,3 @@
-NEXT_PUBLIC_LANGTRACE_VERSION="local"
-
 # Postgres Variables
 POSTGRES_HOST="langtrace-postgres:5432"
 POSTGRES_USER="ltuser"

--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+NEXT_PUBLIC_LANGTRACE_VERSION="local"
+
 # Postgres Variables
 POSTGRES_HOST="langtrace-postgres:5432"
 POSTGRES_USER="ltuser"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -55,6 +55,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           target: production
           push: true
+          build-args: |
+            LANGTRACE_VERSION=${{ inputs.imageTag }}
           tags: |
             ${{ env.DOCKER_REGISTRY }}:${{ inputs.imageTag }}
             ${{ env.DOCKER_REGISTRY }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,14 @@ EXPOSE 3000
 CMD [ "/bin/sh", "-c", "bash entrypoint.sh" ]
 
 
-# Intermediate image for building the application
+# Intermediate image for building the application for production
 FROM development AS builder
 
 WORKDIR /app
 
-RUN NEXT_PUBLIC_ENABLE_ADMIN_LOGIN=true npm run build
+ARG LANGTRACE_VERSION
+
+RUN NEXT_PUBLIC_ENABLE_ADMIN_LOGIN=true NEXT_PUBLIC_LANGTRACE_VERSION=$LANGTRACE_VERSION npm run build
 
 # Final release image
 FROM node:21.6-bookworm AS production

--- a/app/(auth)/login/form.tsx
+++ b/app/(auth)/login/form.tsx
@@ -86,11 +86,11 @@ export default function LoginForm() {
           Sign up
         </Link>
         .
-				{process.env.NEXT_PUBLIC_LANGTRACE_VERSION && (
+        {process.env.NEXT_PUBLIC_LANGTRACE_VERSION && (
           <p className="text-center text-xs text-muted-foreground mt-4">
             Version: {process.env.NEXT_PUBLIC_LANGTRACE_VERSION}
           </p>
-				)}
+        )}
       </p>
     </>
   );

--- a/app/(auth)/login/form.tsx
+++ b/app/(auth)/login/form.tsx
@@ -86,6 +86,11 @@ export default function LoginForm() {
           Sign up
         </Link>
         .
+				{process.env.NEXT_PUBLIC_LANGTRACE_VERSION && (
+          <p className="text-center text-xs text-muted-foreground mt-4">
+            Version: {process.env.NEXT_PUBLIC_LANGTRACE_VERSION}
+          </p>
+				)}
       </p>
     </>
   );

--- a/app/(auth)/signup/form.tsx
+++ b/app/(auth)/signup/form.tsx
@@ -42,6 +42,11 @@ export default function RegisterForm() {
           Sign in
         </Link>
         .
+        {process.env.NEXT_PUBLIC_LANGTRACE_VERSION && (
+          <p className="text-center text-xs text-muted-foreground mt-4">
+            Version: {process.env.NEXT_PUBLIC_LANGTRACE_VERSION}
+          </p>
+        )}
       </p>
     </>
   );

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { Slot } from "@radix-ui/react-slot"
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
 import {
   Controller,
   ControllerProps,
@@ -8,27 +8,27 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
-} from "react-hook-form"
+} from "react-hook-form";
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
-const Form = FormProvider
+const Form = FormProvider;
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  name: TName
-}
+  name: TName;
+};
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
   {} as FormFieldContextValue
-)
+);
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
@@ -36,21 +36,21 @@ const FormField = <
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
     </FormFieldContext.Provider>
-  )
-}
+  );
+};
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
 
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const fieldState = getFieldState(fieldContext.name, formState);
 
   if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
+    throw new Error("useFormField should be used within <FormField>");
   }
 
-  const { id } = itemContext
+  const { id } = itemContext;
 
   return {
     id,
@@ -59,36 +59,36 @@ const useFormField = () => {
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
     ...fieldState,
-  }
-}
+  };
+};
 
 type FormItemContextValue = {
-  id: string
-}
+  id: string;
+};
 
 const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue
-)
+);
 
 const FormItem = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const id = React.useId()
+  const id = React.useId();
 
   return (
     <FormItemContext.Provider value={{ id }}>
       <div ref={ref} className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
-  )
-})
-FormItem.displayName = "FormItem"
+  );
+});
+FormItem.displayName = "FormItem";
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
 >(({ className, ...props }, ref) => {
-  const { error, formItemId } = useFormField()
+  const { error, formItemId } = useFormField();
 
   return (
     <Label
@@ -97,15 +97,16 @@ const FormLabel = React.forwardRef<
       htmlFor={formItemId}
       {...props}
     />
-  )
-})
-FormLabel.displayName = "FormLabel"
+  );
+});
+FormLabel.displayName = "FormLabel";
 
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
 >(({ ...props }, ref) => {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
 
   return (
     <Slot
@@ -119,15 +120,15 @@ const FormControl = React.forwardRef<
       aria-invalid={!!error}
       {...props}
     />
-  )
-})
-FormControl.displayName = "FormControl"
+  );
+});
+FormControl.displayName = "FormControl";
 
 const FormDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => {
-  const { formDescriptionId } = useFormField()
+  const { formDescriptionId } = useFormField();
 
   return (
     <p
@@ -136,19 +137,19 @@ const FormDescription = React.forwardRef<
       className={cn("text-[0.8rem] text-muted-foreground", className)}
       {...props}
     />
-  )
-})
-FormDescription.displayName = "FormDescription"
+  );
+});
+FormDescription.displayName = "FormDescription";
 
 const FormMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
-  const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
 
   if (!body) {
-    return null
+    return null;
   }
 
   return (
@@ -160,17 +161,17 @@ const FormMessage = React.forwardRef<
     >
       {body}
     </p>
-  )
-})
-FormMessage.displayName = "FormMessage"
+  );
+});
+FormMessage.displayName = "FormMessage";
 
 export {
-  useFormField,
   Form,
-  FormItem,
-  FormLabel,
   FormControl,
   FormDescription,
-  FormMessage,
   FormField,
-}
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+};


### PR DESCRIPTION
Adding the version number of the release on the login page.
This helps users identify the Langtrace version they are running and they can easily update their client.