### PR TITLE
fix: release on PR closed

### DIFF
--- a/.github/workflows/release_langtrace.yaml
+++ b/.github/workflows/release_langtrace.yaml
@@ -7,9 +7,14 @@ on:
       - main
     types:
       - closed
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   generate-version:
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-release')
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
- Fixes a bug when Github release workflow is triggered when PR is closed against main.
- Adding an option to skip release when merged to the main.
- do not trigger workflow when there are no client-related changes.