### PR TITLE
Fixed the setup instructions for the typescript sdk

### DIFF
--- a/components/shared/setup-instructions.tsx
+++ b/components/shared/setup-instructions.tsx
@@ -22,7 +22,7 @@ langtrace.init(api_key = '${apiKey ?? "<LANGTRACE_API_KEY>"}')`;
 const typescriptCodeTemplate = (apiKey: string) =>
   `// Must precede any llm module imports
 
-import * as Langtrace from '@langtrace/typescript-sdk'
+import * as Langtrace from '@langtrase/typescript-sdk'
 
 Langtrace.init({ api_key: '${apiKey ?? "<LANGTRACE_API_KEY>"}' })`;
 


### PR DESCRIPTION
There was just one instance of this happening and it was in the shared instructions file.

Should be good to go, and thank you again for building Langtrace