### PR TITLE
Add cleanlab trustworthiness score to traces

### DIFF
--- a/components/project/traces/traces-table.tsx
+++ b/components/project/traces/traces-table.tsx
@@ -94,6 +94,7 @@ export function TracesTable<TData, TValue>({
       output_cost: newMode === "trace",
       total_cost: newMode === "trace",
       total_duration: newMode === "trace",
+      cleanlab_tlm_score: false,
     });
     if (newMode === "prompt") {
       setFilters([

--- a/components/project/traces/traces.tsx
+++ b/components/project/traces/traces.tsx
@@ -394,6 +394,14 @@ export default function Traces({ project_id }: TracesProps) {
       },
     },
     {
+      accessorKey: "cleanlab_tlm_score",
+      header: "Cleanlab TLM Score",
+      cell: ({ row }) => {
+        const score = row.getValue("cleanlab_tlm_score") as number;
+        return <p className="text-xs font-semibold">{score}</p>;
+      },
+    },
+    {
       accessorKey: "total_duration",
       header: "Total Duration",
       cell: ({ row }) => {

--- a/components/shared/vendor-metadata.tsx
+++ b/components/shared/vendor-metadata.tsx
@@ -700,7 +700,7 @@ export function VendorLogo({
         width={80}
         height={80}
         className={cn(
-          `${color} p-[3px]`,
+          `${color} p-[0.5px]`,
           variant === "circular" ? "rounded-full" : "rounded-md"
         )}
       />

--- a/lib/trace_util.ts
+++ b/lib/trace_util.ts
@@ -28,6 +28,7 @@ export interface Trace {
   sorted_trace: any[];
   trace_hierarchy: any[];
   raw_attributes: any;
+  cleanlab_tlm_score?: number;
 }
 
 interface TraceAttributes {
@@ -193,6 +194,7 @@ export function processTrace(trace: any): Trace {
   const promptVersions: string[] = [];
   const messages: Record<string, string[]>[] = [];
   const allEvents: any[] = [];
+  let cleanlab_tlm_score: number | undefined;
 
   let tokenCounts: any = {};
   let totalCost = { total: 0, input: 0, output: 0, cached_input: 0 };
@@ -214,6 +216,14 @@ export function processTrace(trace: any): Trace {
 
     const attrs = parseTraceAttributes(span.attributes);
     lastParsedAttributes = JSON.parse(span.attributes); // Keep for backward compatibility
+
+    // Check for CleanLab trustworthiness score
+    if (
+      attrs.vendor === "cleanlab" &&
+      lastParsedAttributes["tlm.trustworthiness_score"]
+    ) {
+      cleanlab_tlm_score = lastParsedAttributes["tlm.trustworthiness_score"];
+    }
 
     // Update collectors
     session_id = attrs.sessionId || session_id;
@@ -292,5 +302,6 @@ export function processTrace(trace: any): Trace {
     sorted_trace: trace,
     trace_hierarchy: traceHierarchy,
     raw_attributes: lastParsedAttributes,
+    cleanlab_tlm_score,
   };
 }


### PR DESCRIPTION
This PR contains the following
- Extract and add cleanlab trustworthiness score to the traces table