### PR TITLE
fix: handle no port exists scenario gracefully

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ PRISMA_MIGRATIONS_TABLE="_prisma_migrations"
 
 # Extract DB_HOST and DB_PORT from POSTGRES_HOST
 DB_HOST=$(echo $POSTGRES_HOST | cut -d':' -f1)
-DB_PORT=$(echo $POSTGRES_HOST | cut -d':' -f2)
+DB_PORT=$(echo $POSTGRES_HOST | cut -s -d':' -f2)
 
 # Default to port 5432 if DB_PORT is not set
 if [ -z "$DB_PORT" ]; then


### PR DESCRIPTION

If a DB port is not mentioned in `POSTGRES_HOST` value, the value of `DB_PORT` is the same as DB_HOST, this is because cut -f2 returns the same value (first element) when it does not find its index.

to avoid such scenarios, we use `-s` that suppresses output if the delimiter is not found.